### PR TITLE
feat(api): enhance audience export with i18n, theme colors and richer breakdowns

### DIFF
--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -46,12 +46,12 @@
         "user": "You.",
         "organization": "A member of your organization."
       },
-      "external": "Someone signed in through a different account or organization.",
+      "external": "Someone signed in through a personal account or an organization different from yours.",
       "ownerAPIKey": {
         "user": "API key belonging to your account.",
         "organization": "API key belonging to your organization."
       },
-      "externalAPIKey": "API key belonging to another account or organization."
+      "externalAPIKey": "API key belonging to a personal account or an organization different from yours."
     },
     "misc": {
       "unknown": "Unknown"

--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -48,8 +48,8 @@
       },
       "external": "Someone signed in through a different account or organization.",
       "ownerAPIKey": {
-        "user": "API key belonging to your account (automated access from scripts or integrations).",
-        "organization": "API key belonging to your organization (automated access from scripts or integrations)."
+        "user": "API key belonging to your account.",
+        "organization": "API key belonging to your organization."
       },
       "externalAPIKey": "API key belonging to another account or organization."
     },

--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -1,0 +1,60 @@
+{
+  "export": {
+    "sheets": {
+      "global": "Global",
+      "history": "History",
+      "datasets": "Datasets",
+      "topicsApi": "API calls by topic",
+      "originsApi": "API calls by domain",
+      "topicsFiles": "Downloads by topic",
+      "originsFiles": "Downloads by domain",
+      "apps": "Application views"
+    },
+    "columns": {
+      "date": "Date",
+      "id": "Identifier",
+      "title": "Title",
+      "topic": "Topic",
+      "origin": "Domain",
+      "totalApiCalls": "API calls / total",
+      "totalDownloads": "Downloads / total",
+      "apiCallsBy": "API calls / {{userClass}}",
+      "downloadsBy": "Downloads / {{userClass}}",
+      "allUsers": "All users"
+    },
+    "global": {
+      "periodRange": "From {{start}} to {{end}}",
+      "currentPeriod": "Current period",
+      "previousPeriod": "Previous period",
+      "variation": "Change",
+      "apiCalls": "API calls",
+      "fileDownloads": "Files downloaded",
+      "appViews": "Application views",
+      "userClassBreakdown": "Breakdown by user category",
+      "userClassDefinitionsTitle": "User category definitions"
+    },
+    "userClasses": {
+      "anonymous": "Anonymous users",
+      "owner": "Members",
+      "external": "External users",
+      "ownerAPIKey": "Member API keys",
+      "externalAPIKey": "External API keys"
+    },
+    "userClassDefinitions": {
+      "anonymous": "Visitors who are not signed in. They access data without identifying themselves.",
+      "owner": {
+        "user": "You.",
+        "organization": "A member of your organization."
+      },
+      "external": "Someone signed in through a different account or organization.",
+      "ownerAPIKey": {
+        "user": "API key belonging to your account (automated access from scripts or integrations).",
+        "organization": "API key belonging to your organization (automated access from scripts or integrations)."
+      },
+      "externalAPIKey": "API key belonging to another account or organization."
+    },
+    "misc": {
+      "unknown": "Unknown"
+    }
+  }
+}

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -46,12 +46,12 @@
         "user": "Vous.",
         "organization": "Membre de votre organisation."
       },
-      "external": "Personne connectée via un compte ou une organisation différent du vôtre.",
+      "external": "Personne connectée via un compte personnel ou une organisation différente de la vôtre.",
       "ownerAPIKey": {
         "user": "Clé d'API appartenant à votre compte.",
         "organization": "Clé d'API appartenant à votre organisation."
       },
-      "externalAPIKey": "Clé d'API appartenant à un autre compte ou une autre organisation."
+      "externalAPIKey": "Clé d'API appartenant à un compte personnel ou une organisation différente de la vôtre."
     },
     "misc": {
       "unknown": "Inconnu"

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -1,0 +1,60 @@
+{
+  "export": {
+    "sheets": {
+      "global": "Global",
+      "history": "Historique",
+      "datasets": "Jeux de données",
+      "topicsApi": "Appels d'API par thématiques",
+      "originsApi": "Appels d'API par domaines",
+      "topicsFiles": "Téléchargements par thématiques",
+      "originsFiles": "Téléchargements par domaines",
+      "apps": "Affichages d'applications"
+    },
+    "columns": {
+      "date": "Date",
+      "id": "Identifiant",
+      "title": "Titre",
+      "topic": "Thématique",
+      "origin": "Domaine",
+      "totalApiCalls": "Appels API / total",
+      "totalDownloads": "Téléchargements / total",
+      "apiCallsBy": "Appels d'API / {{userClass}}",
+      "downloadsBy": "Téléchargements / {{userClass}}",
+      "allUsers": "Tous les utilisateurs"
+    },
+    "global": {
+      "periodRange": "Du {{start}} au {{end}}",
+      "currentPeriod": "Période actuelle",
+      "previousPeriod": "Période précédente",
+      "variation": "Variation",
+      "apiCalls": "Appels d'API",
+      "fileDownloads": "Fichiers téléchargés",
+      "appViews": "Affichages d'applications",
+      "userClassBreakdown": "Répartition par catégories d'utilisateurs",
+      "userClassDefinitionsTitle": "Définition des catégories d'utilisateurs"
+    },
+    "userClasses": {
+      "anonymous": "Utilisateurs anonymes",
+      "owner": "Utilisateurs membres",
+      "external": "Utilisateurs externes",
+      "ownerAPIKey": "Clés d'API membres",
+      "externalAPIKey": "Clés d'API externes"
+    },
+    "userClassDefinitions": {
+      "anonymous": "Visiteurs non connectés. Ils consultent les données sans s'identifier.",
+      "owner": {
+        "user": "Vous.",
+        "organization": "Membre de votre organisation."
+      },
+      "external": "Personne connectée via un compte ou une organisation différent du vôtre.",
+      "ownerAPIKey": {
+        "user": "Clé d'API appartenant à votre compte (accès automatisés via scripts ou intégrations).",
+        "organization": "Clé d'API appartenant à votre organisation (accès automatisés via scripts ou intégrations)."
+      },
+      "externalAPIKey": "Clé d'API appartenant à un autre compte ou une autre organisation."
+    },
+    "misc": {
+      "unknown": "Inconnu"
+    }
+  }
+}

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -48,8 +48,8 @@
       },
       "external": "Personne connectée via un compte ou une organisation différent du vôtre.",
       "ownerAPIKey": {
-        "user": "Clé d'API appartenant à votre compte (accès automatisés via scripts ou intégrations).",
-        "organization": "Clé d'API appartenant à votre organisation (accès automatisés via scripts ou intégrations)."
+        "user": "Clé d'API appartenant à votre compte.",
+        "organization": "Clé d'API appartenant à votre organisation."
       },
       "externalAPIKey": "Clé d'API appartenant à un autre compte ou une autre organisation."
     },

--- a/api/i18n/utils.ts
+++ b/api/i18n/utils.ts
@@ -1,0 +1,37 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const messagesDir = join(import.meta.dirname, 'messages')
+const messages: Record<string, Record<string, any>> = {}
+for (const file of readdirSync(messagesDir)) {
+  if (file.endsWith('.json')) {
+    const lang = file.slice(0, -5)
+    messages[lang] = JSON.parse(readFileSync(join(messagesDir, file), 'utf8'))
+  }
+}
+
+const defaultLang = 'fr'
+
+const lookup = (lang: string, key: string): string | undefined => {
+  let val: any = messages[lang]
+  for (const part of key.split('.')) {
+    val = val?.[part]
+    if (val === undefined) return undefined
+  }
+  return typeof val === 'string' ? val : undefined
+}
+
+export const t = (lang: string | undefined, key: string, vars?: Record<string, string>): string => {
+  const resolvedLang = lang && messages[lang] ? lang : defaultLang
+  let value = lookup(resolvedLang, key)
+  if (value === undefined && resolvedLang !== defaultLang) {
+    value = lookup(defaultLang, key)
+  }
+  if (value === undefined) return key
+  if (vars) {
+    for (const [k, v] of Object.entries(vars)) {
+      value = value.replaceAll(`{{${k}}}`, v)
+    }
+  }
+  return value
+}

--- a/api/src/daily-api-metrics/export.ts
+++ b/api/src/daily-api-metrics/export.ts
@@ -5,14 +5,10 @@ import type { ExportQuery } from '#doc'
 import Excel from 'exceljs'
 import dayjs from 'dayjs'
 import { getApp, getDataset, getHistory, getOrigin, getTotal, getUserClass } from './service.ts'
+import { t } from '../../i18n/utils.ts'
 
-const userClasses = {
-  anonymous: 'Utilisateurs anonymes',
-  owner: 'Utilisateurs membres',
-  external: 'Utilisateurs externes',
-  ownerAPIKey: 'Clés d\'API membres',
-  externalAPIKey: 'Clés d\'API externes'
-}
+const userClassKeys = ['anonymous', 'owner', 'external', 'ownerAPIKey', 'externalAPIKey'] as const
+type UserClassKey = typeof userClassKeys[number]
 
 const formatDate = (date: string) => dayjs(date).format('DD/MM/YYYY')
 
@@ -30,109 +26,203 @@ type TopicStats = {
   nbRequestsExternal: number
   nbRequestsOwnerAPIKey: number
   nbRequestsExternalAPIKey: number
+  nbFilesAnonymous: number
+  nbFilesOwner: number
+  nbFilesExternal: number
 }
 
+// Default palette used when the site theme is unavailable. Aligned with
+// @data-fair/lib-vuetify baseColors so the export matches the UI defaults.
+const DEFAULT_COLORS = {
+  PRIMARY: '1E88E5',
+  ON_PRIMARY: 'FFFFFF',
+  SUCCESS: '4CAF50',
+  ON_SUCCESS: 'FFFFFF',
+  ERROR: 'FF5252',
+  ON_ERROR: 'FFFFFF',
+  ACCENT: 'FF9800',
+  ON_ACCENT: 'FFFFFF'
+}
+
+// ExcelJS uses ARGB hex without a leading "#"; theme colors come from
+// simple-directory as "#RRGGBB", so we strip the prefix and uppercase.
+const argb = (hex: string | undefined, fallback: string) => {
+  if (!hex) return fallback
+  return hex.replace(/^#/, '').toUpperCase()
+}
+
+const resolveColors = (themeColors?: Record<string, string>) => ({
+  PRIMARY: argb(themeColors?.primary, DEFAULT_COLORS.PRIMARY),
+  ON_PRIMARY: argb(themeColors?.['on-primary'], DEFAULT_COLORS.ON_PRIMARY),
+  SUCCESS: argb(themeColors?.success, DEFAULT_COLORS.SUCCESS),
+  ON_SUCCESS: argb(themeColors?.['on-success'], DEFAULT_COLORS.ON_SUCCESS),
+  ERROR: argb(themeColors?.error, DEFAULT_COLORS.ERROR),
+  ON_ERROR: argb(themeColors?.['on-error'], DEFAULT_COLORS.ON_ERROR),
+  ACCENT: argb(themeColors?.accent, DEFAULT_COLORS.ACCENT),
+  ON_ACCENT: argb(themeColors?.['on-accent'], DEFAULT_COLORS.ON_ACCENT)
+})
+
+type Palette = ReturnType<typeof resolveColors>
+
 // Helper functions for worksheet setup
-const setupWorksheets = (workbook: Excel.stream.xlsx.WorkbookWriter, query: { start: string, end: string }) => {
+const setupWorksheets = (workbook: Excel.stream.xlsx.WorkbookWriter, query: { start: string, end: string }, lang: string | undefined) => {
   workbook.creator = 'Data-Fair'
   workbook.created = new Date()
 
-  const global = workbook.addWorksheet('Global')
+  const userClass = (key: UserClassKey) => t(lang, `export.userClasses.${key}`)
+  const apiCallsBy = (key: UserClassKey) => t(lang, 'export.columns.apiCallsBy', { userClass: userClass(key) })
+  const downloadsBy = (key: UserClassKey) => t(lang, 'export.columns.downloadsBy', { userClass: userClass(key) })
+
+  const global = workbook.addWorksheet(t(lang, 'export.sheets.global'))
   global.getColumn(1).width = 4
   global.getColumn(2).width = 30
   global.getColumn(3).width = 18
   global.getColumn(4).width = 18
   global.getColumn(5).width = 10
   global.addRow([])
-  global.addRow(['', `Du ${formatDate(query.start)} au ${formatDate(query.end)}`, 'Période actuelle', 'Période précédente', 'Variation'])
+  global.addRow([
+    '',
+    t(lang, 'export.global.periodRange', { start: formatDate(query.start), end: formatDate(query.end) }),
+    t(lang, 'export.global.currentPeriod'),
+    t(lang, 'export.global.previousPeriod'),
+    t(lang, 'export.global.variation')
+  ])
 
-  const history = workbook.addWorksheet('Historique')
+  const history = workbook.addWorksheet(t(lang, 'export.sheets.history'))
   history.columns = [
-    { header: 'Date', key: 'day', width: 15 },
-    { header: 'Appels API / total', key: 'nbRequests', width: 25 },
-    { header: 'Téléchargements / total', key: 'nbFiles', width: 25 },
-    { header: 'Appels d\'API / Utilisateurs membres', key: 'nbRequestsOwner', width: 30 },
-    { header: 'Appels d\'API / Utilisateurs externes', key: 'nbRequestsExternal', width: 30 },
-    { header: 'Appels d\'API / Utilisateurs anonymes', key: 'nbRequestsAnonymous', width: 30 },
-    { header: 'Appels d\'API / Clés d\'API membres', key: 'nbRequestsOwnerAPIKey', width: 30 },
-    { header: 'Appels d\'API / Clés d\'API anonymes', key: 'nbRequestsExternalAPIKey', width: 30 },
-    { header: 'Téléchargements / Utilisateurs membres', key: 'nbFilesOwner', width: 30 },
-    { header: 'Téléchargements / Utilisateurs externes', key: 'nbFilesExternal', width: 30 },
-    { header: 'Téléchargements / Utilisateurs anonymes', key: 'nbFilesAnonymous', width: 30 }
+    { header: t(lang, 'export.columns.date'), key: 'day', width: 15 },
+    { header: t(lang, 'export.columns.totalApiCalls'), key: 'nbRequests', width: 25 },
+    { header: t(lang, 'export.columns.totalDownloads'), key: 'nbFiles', width: 25 },
+    { header: apiCallsBy('owner'), key: 'nbRequestsOwner', width: 30 },
+    { header: apiCallsBy('external'), key: 'nbRequestsExternal', width: 30 },
+    { header: apiCallsBy('anonymous'), key: 'nbRequestsAnonymous', width: 30 },
+    { header: apiCallsBy('ownerAPIKey'), key: 'nbRequestsOwnerAPIKey', width: 30 },
+    { header: apiCallsBy('externalAPIKey'), key: 'nbRequestsExternalAPIKey', width: 30 },
+    { header: downloadsBy('owner'), key: 'nbFilesOwner', width: 30 },
+    { header: downloadsBy('external'), key: 'nbFilesExternal', width: 30 },
+    { header: downloadsBy('anonymous'), key: 'nbFilesAnonymous', width: 30 }
   ]
 
-  const dataset = workbook.addWorksheet('Jeux de données')
+  const dataset = workbook.addWorksheet(t(lang, 'export.sheets.datasets'))
   dataset.columns = [
-    { header: 'Identifiant', key: 'id', width: 28 },
-    { header: 'Titre', key: 'title', width: 40 },
-    { header: 'Appels API / total', key: 'nbRequests', width: 25 },
-    { header: 'Téléchargements / total', key: 'nbFiles', width: 25 },
-    { header: 'Appels d\'API / Utilisateurs membres', key: 'nbRequestsOwner', width: 30 },
-    { header: 'Appels d\'API / Utilisateurs externes', key: 'nbRequestsExternal', width: 30 },
-    { header: 'Appels d\'API / Utilisateurs anonymes', key: 'nbRequestsAnonymous', width: 30 },
-    { header: 'Appels d\'API / Clés d\'API membres', key: 'nbRequestsOwnerAPIKey', width: 30 },
-    { header: 'Appels d\'API / Clés d\'API externes', key: 'nbRequestsExternalAPIKey', width: 30 },
-    { header: 'Téléchargements / Utilisateurs membres', key: 'nbFilesOwner', width: 30 },
-    { header: 'Téléchargements / Utilisateurs externes', key: 'nbFilesExternal', width: 30 },
-    { header: 'Téléchargements / Utilisateurs anonymes', key: 'nbFilesAnonymous', width: 30 }
+    { header: t(lang, 'export.columns.id'), key: 'id', width: 28 },
+    { header: t(lang, 'export.columns.title'), key: 'title', width: 40 },
+    { header: t(lang, 'export.columns.totalApiCalls'), key: 'nbRequests', width: 25 },
+    { header: t(lang, 'export.columns.totalDownloads'), key: 'nbFiles', width: 25 },
+    { header: apiCallsBy('owner'), key: 'nbRequestsOwner', width: 30 },
+    { header: apiCallsBy('external'), key: 'nbRequestsExternal', width: 30 },
+    { header: apiCallsBy('anonymous'), key: 'nbRequestsAnonymous', width: 30 },
+    { header: apiCallsBy('ownerAPIKey'), key: 'nbRequestsOwnerAPIKey', width: 30 },
+    { header: apiCallsBy('externalAPIKey'), key: 'nbRequestsExternalAPIKey', width: 30 },
+    { header: downloadsBy('owner'), key: 'nbFilesOwner', width: 30 },
+    { header: downloadsBy('external'), key: 'nbFilesExternal', width: 30 },
+    { header: downloadsBy('anonymous'), key: 'nbFilesAnonymous', width: 30 }
   ]
 
-  const topic = workbook.addWorksheet('Appels d\'API par thématiques')
+  const topic = workbook.addWorksheet(t(lang, 'export.sheets.topicsApi'))
   topic.columns = [
-    { header: 'Thématique', key: 'topic', width: 30 },
-    { header: 'Tous les utilisateurs', key: 'nbRequests', width: 20 },
-    { header: 'Utilisateurs membres', key: 'nbRequestsOwner', width: 20 },
-    { header: 'Utilisateurs externes', key: 'nbRequestsExternal', width: 20 },
-    { header: 'Utilisateurs anonymes', key: 'nbRequestsAnonymous', width: 20 },
-    { header: 'Clés d\'API membres', key: 'nbRequestsOwnerAPIKey', width: 20 },
-    { header: 'Clés d\'API externes', key: 'nbRequestsExternalAPIKey', width: 20 }
+    { header: t(lang, 'export.columns.topic'), key: 'topic', width: 30 },
+    { header: t(lang, 'export.columns.allUsers'), key: 'nbRequests', width: 20 },
+    { header: userClass('owner'), key: 'nbRequestsOwner', width: 20 },
+    { header: userClass('external'), key: 'nbRequestsExternal', width: 20 },
+    { header: userClass('anonymous'), key: 'nbRequestsAnonymous', width: 20 },
+    { header: userClass('ownerAPIKey'), key: 'nbRequestsOwnerAPIKey', width: 20 },
+    { header: userClass('externalAPIKey'), key: 'nbRequestsExternalAPIKey', width: 20 }
   ]
 
-  const origin = workbook.addWorksheet('Appels d\'API par domaines')
+  const origin = workbook.addWorksheet(t(lang, 'export.sheets.originsApi'))
   origin.columns = [
-    { header: 'Domaine', key: 'origin', width: 30 },
-    { header: 'Tous les utilisateurs', key: 'nbRequests', width: 20 },
-    { header: 'Utilisateurs membres', key: 'nbRequestsOwner', width: 20 },
-    { header: 'Utilisateurs externes', key: 'nbRequestsExternal', width: 20 },
-    { header: 'Utilisateurs anonymes', key: 'nbRequestsAnonymous', width: 20 },
-    { header: 'Clés d\'API membres', key: 'nbRequestsOwnerAPIKey', width: 20 },
-    { header: 'Clés d\'API externes', key: 'nbRequestsExternalAPIKey', width: 20 }
+    { header: t(lang, 'export.columns.origin'), key: 'origin', width: 30 },
+    { header: t(lang, 'export.columns.allUsers'), key: 'nbRequests', width: 20 },
+    { header: userClass('owner'), key: 'nbRequestsOwner', width: 20 },
+    { header: userClass('external'), key: 'nbRequestsExternal', width: 20 },
+    { header: userClass('anonymous'), key: 'nbRequestsAnonymous', width: 20 },
+    { header: userClass('ownerAPIKey'), key: 'nbRequestsOwnerAPIKey', width: 20 },
+    { header: userClass('externalAPIKey'), key: 'nbRequestsExternalAPIKey', width: 20 }
   ]
 
-  const app = workbook.addWorksheet('Affichages d\'applications')
+  const topicFiles = workbook.addWorksheet(t(lang, 'export.sheets.topicsFiles'))
+  topicFiles.columns = [
+    { header: t(lang, 'export.columns.topic'), key: 'topic', width: 30 },
+    { header: t(lang, 'export.columns.allUsers'), key: 'nbFiles', width: 20 },
+    { header: userClass('owner'), key: 'nbFilesOwner', width: 20 },
+    { header: userClass('external'), key: 'nbFilesExternal', width: 20 },
+    { header: userClass('anonymous'), key: 'nbFilesAnonymous', width: 20 }
+  ]
+
+  const originFiles = workbook.addWorksheet(t(lang, 'export.sheets.originsFiles'))
+  originFiles.columns = [
+    { header: t(lang, 'export.columns.origin'), key: 'origin', width: 30 },
+    { header: t(lang, 'export.columns.allUsers'), key: 'nbFiles', width: 20 },
+    { header: userClass('owner'), key: 'nbFilesOwner', width: 20 },
+    { header: userClass('external'), key: 'nbFilesExternal', width: 20 },
+    { header: userClass('anonymous'), key: 'nbFilesAnonymous', width: 20 }
+  ]
+
+  const app = workbook.addWorksheet(t(lang, 'export.sheets.apps'))
   app.columns = [
-    { header: 'Identifiant', key: 'id', width: 28 },
-    { header: 'Titre', key: 'title', width: 40 },
-    { header: 'Tous les utilisateurs', key: 'nbRequests', width: 20 },
-    { header: 'Utilisateurs membres', key: 'nbRequestsOwner', width: 20 },
-    { header: 'Utilisateurs externes', key: 'nbRequestsExternal', width: 20 },
-    { header: 'Utilisateurs anonymes', key: 'nbRequestsAnonymous', width: 20 }
+    { header: t(lang, 'export.columns.id'), key: 'id', width: 28 },
+    { header: t(lang, 'export.columns.title'), key: 'title', width: 40 },
+    { header: t(lang, 'export.columns.allUsers'), key: 'nbRequests', width: 20 },
+    { header: userClass('owner'), key: 'nbRequestsOwner', width: 20 },
+    { header: userClass('external'), key: 'nbRequestsExternal', width: 20 },
+    { header: userClass('anonymous'), key: 'nbRequestsAnonymous', width: 20 }
   ]
 
-  return { global, history, dataset, topic, origin, app }
+  return { global, history, dataset, topic, origin, topicFiles, originFiles, app }
 }
 
-const applyGlobalBordersAndFill = (global: Excel.Worksheet) => {
-  const extBorder = { style: 'thin' as const }
+// Style the auto-generated header row (row 1) of a sheet built with `columns`.
+const styleColumnsHeader = (sheet: Excel.Worksheet, palette: Palette) => {
+  const row = sheet.getRow(1)
+  row.eachCell((cell) => {
+    cell.fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: palette.PRIMARY }
+    }
+    cell.font = { ...(cell.font || {}), color: { argb: palette.ON_PRIMARY }, bold: true }
+    cell.border = {
+      top: { style: 'medium' },
+      bottom: { style: 'medium' },
+      left: { style: 'thin' },
+      right: { style: 'thin' }
+    }
+  })
+}
+
+// Apply borders + header styling to a rectangular block. The outer border is
+// medium (thicker) so the two groups stand out; inner cells use hair borders.
+// Cells in the top row OR leftmost column receive a primary fill with on-primary text.
+const applyBlockBordersAndFill = (
+  sheet: Excel.Worksheet,
+  startRow: number,
+  endRow: number,
+  startCol: number,
+  endCol: number,
+  palette: Palette
+) => {
+  const extBorder = { style: 'medium' as const }
   const intBorder = { style: 'hair' as const }
 
-  for (let row = 2; row <= 5; row++) {
-    for (let col = 2; col <= 5; col++) {
-      const cell = global.getCell(row, col)
+  for (let row = startRow; row <= endRow; row++) {
+    for (let col = startCol; col <= endCol; col++) {
+      const cell = sheet.getCell(row, col)
 
       cell.border = {
-        top: row === 2 ? extBorder : intBorder,
-        bottom: (row === 2 || row === 5) ? extBorder : intBorder,
-        left: col === 2 ? extBorder : intBorder,
-        right: (col === 2 || col === 5) ? extBorder : intBorder
+        top: row === startRow ? extBorder : intBorder,
+        bottom: row === endRow ? extBorder : intBorder,
+        left: col === startCol ? extBorder : intBorder,
+        right: col === endCol ? extBorder : intBorder
       }
 
-      if (row === 2 || col === 2) {
+      if (row === startRow || col === startCol) {
         cell.fill = {
           type: 'pattern',
           pattern: 'solid',
-          fgColor: { argb: 'A6D0F4' }
+          fgColor: { argb: palette.PRIMARY }
         }
+        cell.font = { ...(cell.font || {}), color: { argb: palette.ON_PRIMARY }, bold: true }
       }
     }
   }
@@ -154,18 +244,24 @@ const updateTopicStats = (topicsStats: Record<string, TopicStats>, dataset: Data
     stats.nbRequestsAnonymous += datasetMetrics.nbRequestsAnonymous || 0
     stats.nbRequestsOwnerAPIKey += datasetMetrics.nbRequestsOwnerAPIKey || 0
     stats.nbRequestsExternalAPIKey += datasetMetrics.nbRequestsExternalAPIKey || 0
+    stats.nbFilesOwner += datasetMetrics.nbFilesOwner || 0
+    stats.nbFilesExternal += datasetMetrics.nbFilesExternal || 0
+    stats.nbFilesAnonymous += datasetMetrics.nbFilesAnonymous || 0
   }
 }
 
 const generate = async (
   account: Account,
+  lang: string | undefined,
   query: ExportQuery,
   datasetsRes: Dataset[],
   applicationsRes: Application[],
   topics: Topic[],
   baseUrl: string,
+  themeColors: Record<string, string> | undefined,
   res: Response
 ) => {
+  const palette = resolveColors(themeColors)
   const datasetIds = datasetsRes.map(dataset => dataset.id)
   const applicationIds = applicationsRes.map(application => application.id)
 
@@ -176,7 +272,7 @@ const generate = async (
     useSharedStrings: true
   })
 
-  const { global, history, dataset, topic, origin, app } = setupWorksheets(workbook, query)
+  const { global, history, dataset, topic, origin, topicFiles, originFiles, app } = setupWorksheets(workbook, query, lang)
   const topicsStats = topics.reduce((acc, topic) => {
     acc[topic.id] = {
       id: topic.id,
@@ -187,7 +283,10 @@ const generate = async (
       nbRequestsOwner: 0,
       nbRequestsExternal: 0,
       nbRequestsOwnerAPIKey: 0,
-      nbRequestsExternalAPIKey: 0
+      nbRequestsExternalAPIKey: 0,
+      nbFilesAnonymous: 0,
+      nbFilesOwner: 0,
+      nbFilesExternal: 0
     }
     return acc
   }, {} as Record<string, TopicStats>)
@@ -277,9 +376,9 @@ const generate = async (
     updateTopicStats(topicsStats, datasetRes, item)
   }
 
-  // Process topics data
-  const sortedTopics = Object.values(topicsStats).sort((a, b) => b.nbRequests - a.nbRequests)
-  for (const item of sortedTopics) {
+  // Process topics data (API calls)
+  const sortedTopicsApi = Object.values(topicsStats).sort((a, b) => b.nbRequests - a.nbRequests)
+  for (const item of sortedTopicsApi) {
     topic.addRow({
       topic: item.title,
       nbRequests: item.nbRequests,
@@ -291,16 +390,40 @@ const generate = async (
     })
   }
 
-  // Process origin data
+  // Process topics data (downloads)
+  const sortedTopicsFiles = Object.values(topicsStats).sort((a, b) => b.nbFiles - a.nbFiles)
+  for (const item of sortedTopicsFiles) {
+    topicFiles.addRow({
+      topic: item.title,
+      nbFiles: item.nbFiles,
+      nbFilesOwner: item.nbFilesOwner,
+      nbFilesExternal: item.nbFilesExternal,
+      nbFilesAnonymous: item.nbFilesAnonymous
+    })
+  }
+
+  // Process origin data (API calls)
   for (const item of originResults) {
     origin.addRow({
-      origin: item.origin === 'none' ? 'Inconnu' : item.origin,
+      origin: item.origin === 'none' ? t(lang, 'export.misc.unknown') : item.origin,
       nbRequests: item.nbRequests,
       nbRequestsOwner: item.nbRequestsOwner,
       nbRequestsExternal: item.nbRequestsExternal,
       nbRequestsAnonymous: item.nbRequestsAnonymous,
       nbRequestsOwnerAPIKey: item.nbRequestsOwnerAPIKey,
       nbRequestsExternalAPIKey: item.nbRequestsExternalAPIKey
+    })
+  }
+
+  // Process origin data (downloads)
+  const sortedOriginFiles = [...originResults].sort((a, b) => (b.nbFiles || 0) - (a.nbFiles || 0))
+  for (const item of sortedOriginFiles) {
+    originFiles.addRow({
+      origin: item.origin === 'none' ? t(lang, 'export.misc.unknown') : item.origin,
+      nbFiles: item.nbFiles,
+      nbFilesOwner: item.nbFilesOwner,
+      nbFilesExternal: item.nbFilesExternal,
+      nbFilesAnonymous: item.nbFilesAnonymous
     })
   }
 
@@ -328,15 +451,19 @@ const generate = async (
   }
 
   // Add global stats
-  global.addRow(['', 'Appels d\'API', totalResults.current.readDataAPI, totalResults.previous.readDataAPI])
-  global.addRow(['', 'Fichiers téléchargés', totalResults.current.readDataFiles, totalResults.previous.readDataFiles])
-  global.addRow(['', 'Affichages d\'applications', totalResults.current.openApplication, totalResults.previous.openApplication])
+  global.addRow(['', t(lang, 'export.global.apiCalls'), totalResults.current.readDataAPI, totalResults.previous.readDataAPI])
+  global.addRow(['', t(lang, 'export.global.fileDownloads'), totalResults.current.readDataFiles, totalResults.previous.readDataFiles])
+  global.addRow(['', t(lang, 'export.global.appViews'), totalResults.current.openApplication, totalResults.previous.openApplication])
 
-  const COLOR = {
-    POSITIVE: '4CAF50', // Green
-    NEGATIVE: 'FF5252', // Red
-    NEUTRAL: 'C0C0C0'   // Gray
-  }
+  const variationFill = (diff: number) => ({
+    type: 'pattern' as const,
+    pattern: 'solid' as const,
+    fgColor: { argb: diff > 0 ? palette.SUCCESS : (diff < 0 ? palette.ERROR : palette.ACCENT) }
+  })
+  const variationFont = (diff: number) => ({
+    color: { argb: diff > 0 ? palette.ON_SUCCESS : (diff < 0 ? palette.ON_ERROR : palette.ON_ACCENT) },
+    bold: true
+  })
 
   const metrics = [
     { row: 3, current: totalResults.current.readDataAPI, previous: totalResults.previous.readDataAPI },
@@ -353,65 +480,103 @@ const generate = async (
     }
 
     cell.numFmt = '0.00%'
-    cell.fill = {
-      type: 'pattern',
-      pattern: 'solid',
-      fgColor: {
-        argb: diff > 0 ? COLOR.POSITIVE : (diff < 0 ? COLOR.NEGATIVE : COLOR.NEUTRAL)
-      }
-    }
+    cell.fill = variationFill(diff)
+    cell.font = variationFont(diff)
   })
 
-  applyGlobalBordersAndFill(global)
-  global.addRow([])
+  applyBlockBordersAndFill(global, 2, 5, 2, 5, palette)
+  global.addRow([]) // row 6 (separator)
 
   // Add user class stats
-  global.addRow(['', 'Répartition par catégories d\'utilisateurs'])
-  const userClassMap = new Map()
+  const userClassHeaderRow = 7
+  global.addRow(['', t(lang, 'export.global.userClassBreakdown')]) // row 7
+
+  const userClassMap = new Map<string, { className: string, current: number, previous: number }>()
   userClassResults.current.forEach((item: { _id: string; nbRequests: any }) => {
-    if (userClasses[item._id as keyof typeof userClasses]) {
+    if (userClassKeys.includes(item._id as UserClassKey)) {
       userClassMap.set(item._id, {
-        className: userClasses[item._id as keyof typeof userClasses],
+        className: t(lang, `export.userClasses.${item._id}`),
         current: item.nbRequests,
         previous: 0
       })
     }
   })
   userClassResults.previous.forEach((item: { _id: string; nbRequests: any }) => {
-    if (userClassMap.has(item._id)) {
-      userClassMap.get(item._id).previous = item.nbRequests
-    } else if (userClasses[item._id as keyof typeof userClasses]) {
+    const existing = userClassMap.get(item._id)
+    if (existing) {
+      existing.previous = item.nbRequests
+    } else if (userClassKeys.includes(item._id as UserClassKey)) {
       userClassMap.set(item._id, {
-        className: userClasses[item._id as keyof typeof userClasses],
+        className: t(lang, `export.userClasses.${item._id}`),
         current: 0,
         previous: item.nbRequests
       })
     }
   })
 
-  let rowIndex = 8
-  userClassMap.forEach((data, id) => {
+  let userRowIndex = userClassHeaderRow + 1
+  userClassMap.forEach((data) => {
     global.addRow(['', data.className, data.current, data.previous])
 
-    // Calculate and format percentage change
-    const cell = global.getCell(`E${rowIndex}`)
+    const cell = global.getCell(`E${userRowIndex}`)
     const diff = data.current - data.previous
     cell.value = {
-      formula: `=(C${rowIndex}-D${rowIndex})/D${rowIndex}`,
+      formula: `=(C${userRowIndex}-D${userRowIndex})/D${userRowIndex}`,
       result: data.previous !== 0 ? diff / data.previous : diff === 0 ? 0 : 1
     }
 
     cell.numFmt = '0.00%'
-    cell.fill = {
-      type: 'pattern',
-      pattern: 'solid',
-      fgColor: {
-        argb: diff > 0 ? COLOR.POSITIVE : (diff < 0 ? COLOR.NEGATIVE : COLOR.NEUTRAL)
-      }
-    }
-
-    rowIndex++
+    cell.fill = variationFill(diff)
+    cell.font = variationFont(diff)
+    userRowIndex++
   })
+
+  if (userClassMap.size > 0) {
+    applyBlockBordersAndFill(global, userClassHeaderRow, userClassHeaderRow + userClassMap.size, 2, 5, palette)
+  }
+
+  // Add user class definitions block. The descriptions for `owner` and `ownerAPIKey`
+  // vary depending on whether the account is an individual user or an organization.
+  const accountVariant = account.type === 'organization' ? 'organization' : 'user'
+  const definitionKey = (key: UserClassKey) => {
+    if (key === 'owner' || key === 'ownerAPIKey') return `export.userClassDefinitions.${key}.${accountVariant}`
+    return `export.userClassDefinitions.${key}`
+  }
+  const userClassDefinitions: [string, string][] = userClassKeys.map(key => [
+    t(lang, `export.userClasses.${key}`),
+    t(lang, definitionKey(key))
+  ])
+
+  const definitionsHeaderRow = userClassHeaderRow + userClassMap.size + 2
+  global.addRow([]) // separator row
+  global.addRow(['', t(lang, 'export.global.userClassDefinitionsTitle')])
+
+  userClassDefinitions.forEach(([name, description], i) => {
+    const rowNumber = definitionsHeaderRow + 1 + i
+    global.addRow(['', name, description])
+    global.getCell(`C${rowNumber}`).alignment = { wrapText: true, vertical: 'middle' }
+    global.getRow(rowNumber).height = 30
+  })
+
+  // Style before merging so the master cell keeps the styling
+  applyBlockBordersAndFill(global, definitionsHeaderRow, definitionsHeaderRow + userClassDefinitions.length, 2, 5, palette)
+
+  // Patch column C's right border to medium since it becomes the rightmost visible
+  // cell after the C:E merge (the medium border was originally on column E)
+  for (let row = definitionsHeaderRow; row <= definitionsHeaderRow + userClassDefinitions.length; row++) {
+    const cell = global.getCell(`C${row}`)
+    cell.border = { ...(cell.border || {}), right: { style: 'medium' } }
+  }
+
+  global.mergeCells(`C${definitionsHeaderRow}:E${definitionsHeaderRow}`)
+  userClassDefinitions.forEach((_, i) => {
+    global.mergeCells(`C${definitionsHeaderRow + 1 + i}:E${definitionsHeaderRow + 1 + i}`)
+  })
+
+  // Style the column-driven sheets' header rows with the theme's primary palette.
+  for (const sheet of [history, dataset, topic, origin, topicFiles, originFiles, app]) {
+    styleColumnsHeader(sheet, palette)
+  }
 
   await workbook.commit()
 }

--- a/api/src/daily-api-metrics/export.ts
+++ b/api/src/daily-api-metrics/export.ts
@@ -36,6 +36,8 @@ type TopicStats = {
 const DEFAULT_COLORS = {
   PRIMARY: '1E88E5',
   ON_PRIMARY: 'FFFFFF',
+  SECONDARY: '424242',
+  ON_SECONDARY: 'FFFFFF',
   SUCCESS: '4CAF50',
   ON_SUCCESS: 'FFFFFF',
   ERROR: 'FF5252',
@@ -43,6 +45,12 @@ const DEFAULT_COLORS = {
   ACCENT: 'FF9800',
   ON_ACCENT: 'FFFFFF'
 }
+
+// Excel cells need an explicit font name/size; otherwise Excel may fall back
+// to a different default than the workbook's, producing visibly mixed fonts
+// between styled and unstyled cells.
+const FONT_NAME = 'Calibri'
+const FONT_SIZE = 11
 
 // ExcelJS uses ARGB hex without a leading "#"; theme colors come from
 // simple-directory as "#RRGGBB", so we strip the prefix and uppercase.
@@ -54,6 +62,8 @@ const argb = (hex: string | undefined, fallback: string) => {
 const resolveColors = (themeColors?: Record<string, string>) => ({
   PRIMARY: argb(themeColors?.primary, DEFAULT_COLORS.PRIMARY),
   ON_PRIMARY: argb(themeColors?.['on-primary'], DEFAULT_COLORS.ON_PRIMARY),
+  SECONDARY: argb(themeColors?.secondary, DEFAULT_COLORS.SECONDARY),
+  ON_SECONDARY: argb(themeColors?.['on-secondary'], DEFAULT_COLORS.ON_SECONDARY),
   SUCCESS: argb(themeColors?.success, DEFAULT_COLORS.SUCCESS),
   ON_SUCCESS: argb(themeColors?.['on-success'], DEFAULT_COLORS.ON_SUCCESS),
   ERROR: argb(themeColors?.error, DEFAULT_COLORS.ERROR),
@@ -181,10 +191,10 @@ const styleColumnsHeader = (sheet: Excel.Worksheet, palette: Palette) => {
       pattern: 'solid',
       fgColor: { argb: palette.PRIMARY }
     }
-    cell.font = { ...(cell.font || {}), color: { argb: palette.ON_PRIMARY }, bold: true }
+    cell.font = { name: FONT_NAME, size: FONT_SIZE, color: { argb: palette.ON_PRIMARY }, bold: true }
     cell.border = {
       top: { style: 'medium' },
-      bottom: { style: 'medium' },
+      bottom: { style: 'thin' },
       left: { style: 'thin' },
       right: { style: 'thin' }
     }
@@ -193,7 +203,8 @@ const styleColumnsHeader = (sheet: Excel.Worksheet, palette: Palette) => {
 
 // Apply borders + header styling to a rectangular block. The outer border is
 // medium (thicker) so the two groups stand out; inner cells use hair borders.
-// Cells in the top row OR leftmost column receive a primary fill with on-primary text.
+// The top row uses the primary palette (header), and the leftmost column of the
+// remaining rows uses the secondary palette (row legends).
 const applyBlockBordersAndFill = (
   sheet: Excel.Worksheet,
   startRow: number,
@@ -216,13 +227,20 @@ const applyBlockBordersAndFill = (
         right: col === endCol ? extBorder : intBorder
       }
 
-      if (row === startRow || col === startCol) {
+      if (row === startRow) {
         cell.fill = {
           type: 'pattern',
           pattern: 'solid',
           fgColor: { argb: palette.PRIMARY }
         }
-        cell.font = { ...(cell.font || {}), color: { argb: palette.ON_PRIMARY }, bold: true }
+        cell.font = { name: FONT_NAME, size: FONT_SIZE, color: { argb: palette.ON_PRIMARY }, bold: true }
+      } else if (col === startCol) {
+        cell.fill = {
+          type: 'pattern',
+          pattern: 'solid',
+          fgColor: { argb: palette.SECONDARY }
+        }
+        cell.font = { name: FONT_NAME, size: FONT_SIZE, color: { argb: palette.ON_SECONDARY }, bold: true }
       }
     }
   }
@@ -461,6 +479,8 @@ const generate = async (
     fgColor: { argb: diff > 0 ? palette.SUCCESS : (diff < 0 ? palette.ERROR : palette.ACCENT) }
   })
   const variationFont = (diff: number) => ({
+    name: FONT_NAME,
+    size: FONT_SIZE,
     color: { argb: diff > 0 ? palette.ON_SUCCESS : (diff < 0 ? palette.ON_ERROR : palette.ON_ACCENT) },
     bold: true
   })
@@ -561,17 +581,13 @@ const generate = async (
   // Style before merging so the master cell keeps the styling
   applyBlockBordersAndFill(global, definitionsHeaderRow, definitionsHeaderRow + userClassDefinitions.length, 2, 5, palette)
 
-  // Patch column C's right border to medium since it becomes the rightmost visible
-  // cell after the C:E merge (the medium border was originally on column E)
-  for (let row = definitionsHeaderRow; row <= definitionsHeaderRow + userClassDefinitions.length; row++) {
+  // Only the description rows merge C:E; the title row is left unmerged so the
+  // title text can overflow visually like in the breakdown block above.
+  for (let row = definitionsHeaderRow + 1; row <= definitionsHeaderRow + userClassDefinitions.length; row++) {
     const cell = global.getCell(`C${row}`)
     cell.border = { ...(cell.border || {}), right: { style: 'medium' } }
+    global.mergeCells(`C${row}:E${row}`)
   }
-
-  global.mergeCells(`C${definitionsHeaderRow}:E${definitionsHeaderRow}`)
-  userClassDefinitions.forEach((_, i) => {
-    global.mergeCells(`C${definitionsHeaderRow + 1 + i}:E${definitionsHeaderRow + 1 + i}`)
-  })
 
   // Style the column-driven sheets' header rows with the theme's primary palette.
   for (const sheet of [history, dataset, topic, origin, topicFiles, originFiles, app]) {

--- a/api/src/daily-api-metrics/router.ts
+++ b/api/src/daily-api-metrics/router.ts
@@ -72,5 +72,18 @@ router.get('/_export', async (req, res) => {
     }
   )).data || []
 
-  await generate(reqSession.account, query, datasets, applications, topics, reqOrigin(req), res)
+  // Fetch site theme so the export styling matches the site's palette.
+  // Failure here is non-fatal: the export falls back to default colors.
+  let themeColors: Record<string, string> | undefined
+  try {
+    const siteInfo = (await axios.get(
+      new URL('/simple-directory/api/sites/_public', reqOrigin(req)).toString(),
+      { headers: { Cookie: req.headers.cookie } }
+    )).data
+    themeColors = siteInfo?.theme?.colors
+  } catch {
+    themeColors = undefined
+  }
+
+  await generate(reqSession.account, reqSession.lang, query, datasets, applications, topics, reqOrigin(req), themeColors, res)
 })

--- a/api/src/daily-api-metrics/service.ts
+++ b/api/src/daily-api-metrics/service.ts
@@ -272,9 +272,21 @@ export const getOrigin = async (account: Account, query: { start: string, end: s
     day: {
       $gte: query.start,
       $lte: query.end
-    }
+    },
+    operationTrack: { $in: ['readDataAPI', 'readDataFiles'] }
   }
   if (account.department) $match['owner.department'] = account.department
+
+  const apiCond = (userClass?: string) => {
+    const conds: any[] = [{ $eq: ['$_id.operationTrack', 'readDataAPI'] }]
+    if (userClass) conds.push({ $eq: ['$_id.userClass', userClass] })
+    return { $sum: { $cond: [conds.length > 1 ? { $and: conds } : conds[0], '$nbRequests', 0] } }
+  }
+  const filesCond = (userClass?: string) => {
+    const conds: any[] = [{ $eq: ['$_id.operationTrack', 'readDataFiles'] }]
+    if (userClass) conds.push({ $eq: ['$_id.userClass', userClass] })
+    return { $sum: { $cond: [conds.length > 1 ? { $and: conds } : conds[0], '$nbRequests', 0] } }
+  }
 
   const aggregate = [
     { $match },
@@ -282,21 +294,29 @@ export const getOrigin = async (account: Account, query: { start: string, end: s
       $group: {
         _id: {
           origin: '$refererDomain',
-          userClass: '$userClass'
+          userClass: '$userClass',
+          operationTrack: '$operationTrack'
         },
-        nbRequests: { $sum: '$nbRequests' },
+        nbRequests: { $sum: '$nbRequests' }
       }
     },
     {
       $group: {
         _id: '$_id.origin',
-        nbRequests: { $sum: '$nbRequests' },
-        nbRequestsAnonymous: { $sum: { $cond: [{ $eq: ['$_id.userClass', 'anonymous'] }, '$nbRequests', 0] } },
-        nbRequestsOwner: { $sum: { $cond: [{ $eq: ['$_id.userClass', 'owner'] }, '$nbRequests', 0] } },
-        nbRequestsUser: { $sum: { $cond: [{ $eq: ['$_id.userClass', 'user'] }, '$nbRequests', 0] } },
-        nbRequestsExternal: { $sum: { $cond: [{ $eq: ['$_id.userClass', 'external'] }, '$nbRequests', 0] } },
-        nbRequestsOwnerAPIKey: { $sum: { $cond: [{ $eq: ['$_id.userClass', 'ownerAPIKey'] }, '$nbRequests', 0] } },
-        nbRequestsExternalAPIKey: { $sum: { $cond: [{ $eq: ['$_id.userClass', 'externalAPIKey'] }, '$nbRequests', 0] } },
+        nbRequests: apiCond(),
+        nbRequestsAnonymous: apiCond('anonymous'),
+        nbRequestsOwner: apiCond('owner'),
+        nbRequestsUser: apiCond('user'),
+        nbRequestsExternal: apiCond('external'),
+        nbRequestsOwnerAPIKey: apiCond('ownerAPIKey'),
+        nbRequestsExternalAPIKey: apiCond('externalAPIKey'),
+        nbFiles: filesCond(),
+        nbFilesAnonymous: filesCond('anonymous'),
+        nbFilesOwner: filesCond('owner'),
+        nbFilesUser: filesCond('user'),
+        nbFilesExternal: filesCond('external'),
+        nbFilesOwnerAPIKey: filesCond('ownerAPIKey'),
+        nbFilesExternalAPIKey: filesCond('externalAPIKey')
       }
     },
     {
@@ -304,13 +324,19 @@ export const getOrigin = async (account: Account, query: { start: string, end: s
         _id: 0,
         origin: '$_id',
         nbRequests: 1,
-        nbFiles: 1,
         nbRequestsAnonymous: 1,
         nbRequestsOwner: 1,
         nbRequestsUser: 1,
         nbRequestsExternal: 1,
         nbRequestsOwnerAPIKey: 1,
-        nbRequestsExternalAPIKey: 1
+        nbRequestsExternalAPIKey: 1,
+        nbFiles: 1,
+        nbFilesAnonymous: 1,
+        nbFilesOwner: 1,
+        nbFilesUser: 1,
+        nbFilesExternal: 1,
+        nbFilesOwnerAPIKey: 1,
+        nbFilesExternalAPIKey: 1
       }
     },
     { $sort: { nbRequests: -1 } }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3955,12 +3955,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -5912,9 +5912,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -8926,9 +8926,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary
- Add i18n (FR/EN) to the audience PDF export
- Style the export with the site's theme colors
- Split API requests vs file downloads per user class in the origin breakdown
- Improve fonts consistency and fix overflow issues in the rendered PDF

## Changes
- **i18n**: new `api/i18n/messages/{fr,en}.json` and a small `t()` helper in `api/i18n/utils.ts` (lang fallback + `{{var}}` interpolation). The export now uses the session language.
- **Theme colors**: router fetches `/simple-directory/api/sites/_public` to read `theme.colors` and passes them to `generate()`. Failure is non-fatal and falls back to defaults.
- **Origin breakdown**: `getOrigin` aggregation now groups on `operationTrack` too, exposing `nbRequests*` (readDataAPI) and `nbFiles*` (readDataFiles) per user class (anonymous, owner, user, external, ownerAPIKey, externalAPIKey).
- **Export rendering**: refactor of `export.ts` for consistent typography, alignment and overflow handling; clearer wording for external user / API key labels.